### PR TITLE
Fix link to not use <code> tags

### DIFF
--- a/files/en-us/web/css/image/paint/index.md
+++ b/files/en-us/web/css/image/paint/index.md
@@ -95,7 +95,7 @@ We've included a custom property in the selector block defining a boxColor. Cust
 ## See also
 
 - {{domxref('PaintWorklet')}}
-- {{domxref('CSS Painting API')}}
+- [CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API)
 - [Using the CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API/Guide)
 - {{cssxref("&lt;image&gt;")}}
 - {{domxref("canvas")}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Changed link to a plain link rather than one wrapped in `<code>` tags.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
`{{domxref()}}`, `{{cssxref()}}`, etc. should only be used if the parenthesized content should be shown as code.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
